### PR TITLE
Convert lab to sqlite3, add skeleton for policies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'pundit'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.2'
 # Use sqlite3 as the database for Active Record
@@ -46,8 +45,8 @@ end
 gem 'devise'
 gem 'devise_invitable'
 gem 'high_voltage'
-gem 'pg'
 gem 'pundit'
+gem 'sqlite3'
 
 group :development do
   gem 'better_errors'
@@ -70,4 +69,3 @@ group :test do
   gem 'launchy'
   gem 'selenium-webdriver'
 end
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,6 @@ GEM
     nokogiri (1.6.7.1)
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
-    pg (0.18.4)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     quiet_assets (1.1.0)
@@ -191,6 +190,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.11)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -229,7 +229,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   launchy
-  pg
   pundit
   quiet_assets
   rails (= 4.2.2)
@@ -241,6 +240,7 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-commands-rspec
+  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,2 @@
+class ApplicationPolicy
+end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,2 @@
+class UserPolicy < ApplicationPolicy
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,57 +1,25 @@
-# PostgreSQL. Versions 8.2 and up are supported.
+# SQLite version 3.x
+#   gem install sqlite3
 #
-# Install the pg driver:
-#   gem install pg
-# On Mac OS X with macports:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
+#   Ensure the SQLite 3 gem is defined in your Gemfile
+#   gem 'sqlite3'
 #
-# Configure Using Gemfile
-# gem 'pg'
-#
+default: &default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+
 development:
-  adapter:  postgresql
-  host:     localhost
-  encoding: unicode
-  database: devise_pundit_lab_development
-  pool:     5
-
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # The server defaults to notice.
-  #min_messages: warning
+  <<: *default
+  database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter:  postgresql
-  host:     localhost
-  encoding: unicode
-  database: devise_pundit_lab_test
-  pool:     5
-
+  <<: *default
+  database: db/test.sqlite3
 
 production:
-  adapter:  postgresql
-  host:     localhost
-  encoding: unicode
-  database: devise_pundit_lab_production
-  pool:     5
-  username: devise_pundit_lab
-  password:
-  template: template0
+  <<: *default
+  database: db/production.sqlite3

--- a/db/migrate/20151213020140_create_notes.rb
+++ b/db/migrate/20151213020140_create_notes.rb
@@ -2,7 +2,7 @@ class CreateNotes < ActiveRecord::Migration
   def change
     create_table :notes do |t|
       t.string :content
-      t.references :user, index: true, foreign_key: true
+      t.references :user, index: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20151213020228_create_viewers.rb
+++ b/db/migrate/20151213020228_create_viewers.rb
@@ -1,8 +1,8 @@
 class CreateViewers < ActiveRecord::Migration
   def change
     create_table :viewers do |t|
-      t.references :note, index: true, foreign_key: true
-      t.references :user, index: true, foreign_key: true
+      t.references :note, index: true
+      t.references :user, index: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20160119074042_devise_create_users.rb
+++ b/db/migrate/20160119074042_devise_create_users.rb
@@ -16,8 +16,8 @@ class DeviseCreateUsers < ActiveRecord::Migration
       t.integer  :sign_in_count, default: 0, null: false
       t.datetime :current_sign_in_at
       t.datetime :last_sign_in_at
-      t.inet     :current_sign_in_ip
-      t.inet     :last_sign_in_ip
+      t.string   :current_sign_in_ip
+      t.string   :last_sign_in_ip
 
       ## Confirmable
       # t.string   :confirmation_token

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,9 +13,6 @@
 
 ActiveRecord::Schema.define(version: 20160119074046) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "notes", force: :cascade do |t|
     t.string   "content"
     t.integer  "user_id"
@@ -23,7 +20,7 @@ ActiveRecord::Schema.define(version: 20160119074046) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "notes", ["user_id"], name: "index_notes_on_user_id", using: :btree
+  add_index "notes", ["user_id"], name: "index_notes_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "", null: false
@@ -34,8 +31,8 @@ ActiveRecord::Schema.define(version: 20160119074046) do
     t.integer  "sign_in_count",          default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.inet     "current_sign_in_ip"
-    t.inet     "last_sign_in_ip"
+    t.string   "current_sign_in_ip"
+    t.string   "last_sign_in_ip"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.string   "name"
@@ -45,8 +42,8 @@ ActiveRecord::Schema.define(version: 20160119074046) do
     t.string   "unconfirmed_email"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["email"], name: "index_users_on_email", unique: true
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
   create_table "viewers", force: :cascade do |t|
     t.integer  "note_id"
@@ -55,10 +52,7 @@ ActiveRecord::Schema.define(version: 20160119074046) do
     t.datetime "updated_at", null: false
   end
 
-  add_index "viewers", ["note_id"], name: "index_viewers_on_note_id", using: :btree
-  add_index "viewers", ["user_id"], name: "index_viewers_on_user_id", using: :btree
+  add_index "viewers", ["note_id"], name: "index_viewers_on_note_id"
+  add_index "viewers", ["user_id"], name: "index_viewers_on_user_id"
 
-  add_foreign_key "notes", "users"
-  add_foreign_key "viewers", "notes"
-  add_foreign_key "viewers", "users"
 end


### PR DESCRIPTION
Fixes #6
Obsoletes #8
Fixes #11
Fixes #15

This commit adds empty ApplicationPolicy and UserPolicy classes so that tests can run.
This commit also removes dependencies on postgres and instead sets users up for sqlite3.

There were some postgres-specific features (namely, foreign key constraints and inet columns) in some migrations, but everything seems to be running smoothly.

cc @AnnJohn @vicfriedman 
